### PR TITLE
Change artifactId to com.bsb.common.vaadin-embed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>7</version>
     </parent>
     <groupId>com.bsb.common</groupId>
-    <artifactId>com.bsb.common.vaadin.embed</artifactId>
+    <artifactId>com.bsb.common.vaadin-embed</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Vaadin Embed</name>


### PR DESCRIPTION
Following our maven naming conventions, I believe the artifactId should be com.bsb.common.vaadin-embed.
